### PR TITLE
fix(ci): lowercase GHCR image path (unblocks CD)

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -12,7 +12,8 @@ concurrency:
   cancel-in-progress: false
 
 env:
-  IMAGE: ghcr.io/${{ github.repository_owner }}/baiyue
+  # GHCR requires a lowercase repo path; hardcode it (owner "PaynePew" would break the tag).
+  IMAGE: ghcr.io/paynepew/baiyue
 
 jobs:
   build-and-push:


### PR DESCRIPTION
CD run 27701788142 failed: `invalid tag ghcr.io/PaynePew/baiyue:latest: repository name must be lowercase`. `github.repository_owner` is `PaynePew` (mixed case); GHCR requires lowercase. Hardcodes `ghcr.io/paynepew/baiyue` to match docker-compose.prod.yml. One-line CD fix; re-triggers deploy on merge.